### PR TITLE
Fix include guards for MetaEditor compatibility

### DIFF
--- a/MQL5/Include/RPEA/adaptive.mqh
+++ b/MQL5/Include/RPEA/adaptive.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_ADAPTIVE_MQH
+#define RPEA_ADAPTIVE_MQH
 // adaptive.mqh - Adaptive risk multiplier (M1 stub)
 // References: finalspec.md (Adaptive Risk Allocator)
 
@@ -7,3 +8,4 @@ double Adaptive_RiskMultiplier(const string regime_label, const double efficienc
    // TODO[M7]: scale risk by regime/efficiency/room
    return 1.0;
 }
+#endif // RPEA_ADAPTIVE_MQH

--- a/MQL5/Include/RPEA/allocator.mqh
+++ b/MQL5/Include/RPEA/allocator.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_ALLOCATOR_MQH
+#define RPEA_ALLOCATOR_MQH
 // allocator.mqh - Risk allocator stubs (M1)
 // References: finalspec.md (Allocator Enhancements)
 
@@ -16,3 +17,4 @@ OrderPlan Allocator_BuildOrderPlan(const AppContext& ctx,
    OrderPlan p; p.hasPlan=false; p.volume=0.0; p.price=0.0;
    return p;
 }
+#endif // RPEA_ALLOCATOR_MQH

--- a/MQL5/Include/RPEA/anomaly.mqh
+++ b/MQL5/Include/RPEA/anomaly.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_ANOMALY_MQH
+#define RPEA_ANOMALY_MQH
 // anomaly.mqh - Anomaly detection stubs
 // References: finalspec.md (Anomaly/Shock Detector)
 
@@ -7,3 +8,4 @@ bool Anomaly_IsShockNow(const string symbol)
    // TODO[M6]: EWMA z-scores and shock handling
    return false;
 }
+#endif // RPEA_ANOMALY_MQH

--- a/MQL5/Include/RPEA/bandit.mqh
+++ b/MQL5/Include/RPEA/bandit.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_BANDIT_MQH
+#define RPEA_BANDIT_MQH
 // bandit.mqh - Contextual bandit stubs (M1)
 // References: finalspec.md (Contextual Bandit Meta‑Policy)
 
@@ -10,3 +11,4 @@ BanditPolicy Bandit_SelectPolicy(const AppContext& ctx, const string symbol)
    // TODO[M7]: Thompson/LinUCB with posterior persistence
    return Bandit_Skip;
 }
+#endif // RPEA_BANDIT_MQH

--- a/MQL5/Include/RPEA/emrt.mqh
+++ b/MQL5/Include/RPEA/emrt.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_EMRT_MQH
+#define RPEA_EMRT_MQH
 // emrt.mqh - EMRT cache IO stubs (M1)
 // References: finalspec.md (EMRT Formation)
 
@@ -6,3 +7,4 @@ void EMRT_RefreshWeekly()
 {
    // TODO[M7]: formation on synthetic spreads and β grid
 }
+#endif // RPEA_EMRT_MQH

--- a/MQL5/Include/RPEA/learning.mqh
+++ b/MQL5/Include/RPEA/learning.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_LEARNING_MQH
+#define RPEA_LEARNING_MQH
 // learning.mqh - Calibration & learning stubs (M1)
 // References: finalspec.md (Online Learning & Calibration)
 
@@ -11,3 +12,4 @@ void Learning_Update()
 {
    // TODO[M7]: apply updates; freeze on SLO breaches
 }
+#endif // RPEA_LEARNING_MQH

--- a/MQL5/Include/RPEA/liquidity.mqh
+++ b/MQL5/Include/RPEA/liquidity.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_LIQUIDITY_MQH
+#define RPEA_LIQUIDITY_MQH
 // liquidity.mqh - Spread/slippage gates (M1 stubs)
 // References: finalspec.md (Liquidity Intelligence)
 
@@ -12,3 +13,4 @@ void Liquidity_UpdateStats(const string symbol)
 {
    // TODO[M6]: update rolling spread/slippage stats
 }
+#endif // RPEA_LIQUIDITY_MQH

--- a/MQL5/Include/RPEA/logging.mqh
+++ b/MQL5/Include/RPEA/logging.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_LOGGING_MQH
+#define RPEA_LOGGING_MQH
 // logging.mqh - CSV audit/log API (M1)
 // References: finalspec.md (Logging)
 
@@ -46,3 +47,4 @@ void LogDecision(const string component, const string message, const string fiel
 }
 
 // TODO[M5]: structured CSV headers and rotation
+#endif // RPEA_LOGGING_MQH

--- a/MQL5/Include/RPEA/meta_policy.mqh
+++ b/MQL5/Include/RPEA/meta_policy.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_META_POLICY_MQH
+#define RPEA_META_POLICY_MQH
 // meta_policy.mqh - Meta-Policy chooser (M1 stubs)
 // References: finalspec.md (Meta-Policy (BWISC + MR Ensemble))
 
@@ -10,3 +11,4 @@ string MetaPolicy_Choose(const bool bw_has, const double bw_conf,
    if(mr_has) return "MR";
    return "Skip";
 }
+#endif // RPEA_META_POLICY_MQH

--- a/MQL5/Include/RPEA/news.mqh
+++ b/MQL5/Include/RPEA/news.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_NEWS_MQH
+#define RPEA_NEWS_MQH
 // news.mqh - News filter stubs (M1)
 // References: finalspec.md (News Compliance)
 
@@ -31,3 +32,4 @@ void News_PostNewsStabilization()
 {
    // TODO[M4]: post-news stabilization checks
 }
+#endif // RPEA_NEWS_MQH

--- a/MQL5/Include/RPEA/order_engine.mqh
+++ b/MQL5/Include/RPEA/order_engine.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_ORDER_ENGINE_MQH
+#define RPEA_ORDER_ENGINE_MQH
 // order_engine.mqh - Order engine scaffolding (M1)
 // References: finalspec.md (Order Engine)
 
@@ -20,3 +21,4 @@ void OrderEngine_OnTradeTxn(const MqlTradeTransaction& trans,
 {
    // TODO[M3]: reconciliation and OCO pairing
 }
+#endif // RPEA_ORDER_ENGINE_MQH

--- a/MQL5/Include/RPEA/persistence.mqh
+++ b/MQL5/Include/RPEA/persistence.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_PERSISTENCE_MQH
+#define RPEA_PERSISTENCE_MQH
 // persistence.mqh - Persistence & folder creation (M1 stubs)
 // References: finalspec.md (Persistence/Logs & Learning Artifacts)
 
@@ -271,3 +272,4 @@ void Persistence_Flush()
    }
    // TODO[M4/M6]: idempotent recovery and TTL for queued actions
 }
+#endif // RPEA_PERSISTENCE_MQH

--- a/MQL5/Include/RPEA/persistence.mqh
+++ b/MQL5/Include/RPEA/persistence.mqh
@@ -3,7 +3,6 @@
 // persistence.mqh - Persistence & folder creation (M1 stubs)
 // References: finalspec.md (Persistence/Logs & Learning Artifacts)
 
-#include <Files\\File.mqh>
 #include <RPEA/config.mqh>
 #include <RPEA/state.mqh>
 

--- a/MQL5/Include/RPEA/regime.mqh
+++ b/MQL5/Include/RPEA/regime.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_REGIME_MQH
+#define RPEA_REGIME_MQH
 // regime.mqh - Regime detection API (M1 stubs)
 // References: finalspec.md (Market Regime Detection)
 
@@ -12,3 +13,4 @@ void Regime_Features(const string symbol)
 {
    // TODO[M6]: populate features for meta-policy
 }
+#endif // RPEA_REGIME_MQH

--- a/MQL5/Include/RPEA/risk.mqh
+++ b/MQL5/Include/RPEA/risk.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_RISK_MQH
+#define RPEA_RISK_MQH
 // risk.mqh - Risk sizing helpers (M1 stubs)
 // References: finalspec.md (Sizing by ATR distance)
 
@@ -18,3 +19,4 @@ double Risk_SizingByATRDistance(const double entry, const double stop,
    return raw_volume;
    // TODO[M2]: full sizing and margin guard per spec
 }
+#endif // RPEA_RISK_MQH

--- a/MQL5/Include/RPEA/rl_agent.mqh
+++ b/MQL5/Include/RPEA/rl_agent.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_RL_AGENT_MQH
+#define RPEA_RL_AGENT_MQH
 // rl_agent.mqh - Q-table load/save stubs (M1)
 // References: finalspec.md (Q-Learning Training Parameters)
 
@@ -7,3 +8,4 @@ int RL_ActionForState(const int state_id)
    // TODO[M7]: implement Q-table action selection
    return 0; // placeholder action
 }
+#endif // RPEA_RL_AGENT_MQH

--- a/MQL5/Include/RPEA/synthetic.mqh
+++ b/MQL5/Include/RPEA/synthetic.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_SYNTHETIC_MQH
+#define RPEA_SYNTHETIC_MQH
 // synthetic.mqh - Synthetic XAUEUR stubs (M1)
 // References: finalspec.md (Synthetic Cross Support)
 
@@ -19,3 +20,4 @@ double Synthetic_ReplicationSizing()
    // TODO[M3/M7]: replication sizing math
    return 0.0;
 }
+#endif // RPEA_SYNTHETIC_MQH

--- a/MQL5/Include/RPEA/telemetry.mqh
+++ b/MQL5/Include/RPEA/telemetry.mqh
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RPEA_TELEMETRY_MQH
+#define RPEA_TELEMETRY_MQH
 // telemetry.mqh - Telemetry stubs (M1)
 // References: finalspec.md (Telemetry & SLOs)
 
@@ -11,3 +12,4 @@ void Telemetry_AutoThrottle()
 {
    // TODO[M7]: SLO thresholds and auto-risk reduction
 }
+#endif // RPEA_TELEMETRY_MQH


### PR DESCRIPTION
## Summary
- replace unsupported `#pragma once` directives in the RPEA header stubs with explicit include guards so MetaEditor accepts the files

## Testing
- not run (MetaEditor is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c927cff0ac83209bf1a250fbc68463
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced unsupported #pragma once with explicit include guards across RPEA MQL5 headers to restore MetaEditor compatibility. This fixes compilation errors without changing behavior.

- **Bug Fixes**
  - Swapped #pragma once for #ifndef/#define/#endif guards in Include/RPEA/*.mqh
  - Used consistent guard names: RPEA_<FILE>_MQH
  - No runtime or API changes; header-only compatibility fix

<!-- End of auto-generated description by cubic. -->

